### PR TITLE
Relax matching on job name

### DIFF
--- a/stackhpc_monasca_agent_plugins/checks/slurm.py
+++ b/stackhpc_monasca_agent_plugins/checks/slurm.py
@@ -28,7 +28,7 @@ _METRIC_NAME = "job_status"
 _SLURM_LIST_JOBS_CMD = ['/usr/bin/scontrol', '-o', 'show', 'job']
 _SLURM_LIST_NODES_CMD = ['/usr/bin/scontrol', '-o', 'show', 'node']
 
-_SLURM_JOB_FIELD_REGEX = ('^JobId=([\d]+)\sJobName=((?i)[\w-]+\.[\w-]+)\sUserI'
+_SLURM_JOB_FIELD_REGEX = ('^JobId=([\d]+)\sJobName=(.*?)\sUserI'
                           'd=([\w-]+\([\w-]+\)) GroupId=([\w-]+\([\w-]+\))\s.*'
                           'JobState=([\w]+)\s.*\sNodeList=(.*?)\s.*$')
 _SLURM_NODE_FIELD_REGEX = '^NodeName=(.*?)\s.*State=(.*?)\s.*$'


### PR DESCRIPTION
Before this change job names were assumed to be in the format
`some_script.sh`, however this may not always be the case. For example,
when running MPI benchmarks the job name might be: `IMB-MPI1`. This
change makes the regex more flexible so that it can match a wider
range of job names.