### PR TITLE
Plugin for nVidia GPUs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,3 +11,4 @@ Includes:
 
 * Infiniband metrics
 * Slurm (proof-of-concept)
+* nVidia GPUs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+nvidia-ml-py

--- a/stackhpc_monasca_agent_plugins/checks/nvidia.py
+++ b/stackhpc_monasca_agent_plugins/checks/nvidia.py
@@ -1,0 +1,225 @@
+# Copyright (c) 2018 StackHPC Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import logging
+import monasca_agent.collector.checks as checks
+import pynvml
+
+
+log = logging.getLogger(__name__)
+
+_METRIC_NAME_PREFIX = "nvidia"
+_METRIC_NAME = "job_status"
+
+
+class Nvidia(checks.AgentCheck):
+    def __init__(self, name, init_config, agent_config):
+        super(Nvidia, self).__init__(name, init_config, agent_config)
+
+    def handle_not_supported(f):
+        def wrapper(*args, **kw):
+            try:
+                return f(*args, **kw)
+            except pynvml.NVMLError as err:
+                if pynvml.NVML_ERROR_NOT_SUPPORTED in err:
+                    log.info('Not supported: {}'.format(f.__name__))
+                    return {}
+                else:
+                    raise
+        return wrapper
+
+    @staticmethod
+    @handle_not_supported
+    def _get_driver_version():
+        return {'driver_version': pynvml.nvmlSystemGetDriverVersion()}
+
+    @staticmethod
+    @handle_not_supported
+    def _get_fan_speed_percent(gpu):
+        return {'fan_speed_percent': pynvml.nvmlDeviceGetFanSpeed(gpu)}
+
+    @staticmethod
+    @handle_not_supported
+    def _get_device_name(gpu):
+        return {'name': pynvml.nvmlDeviceGetName(gpu)}
+
+    @staticmethod
+    @handle_not_supported
+    def _get_device_serial(gpu):
+        return {'serial': pynvml.nvmlDeviceGetSerial(gpu)}
+
+    @staticmethod
+    @handle_not_supported
+    def _get_device_uuid(gpu):
+        return {'uuid': pynvml.nvmlDeviceGetUUID(gpu)}
+
+    @staticmethod
+    @handle_not_supported
+    def _get_device_vbios_version(gpu):
+        return {'vbios_version': pynvml.nvmlDeviceGetVbiosVersion(gpu)}
+
+    @staticmethod
+    @handle_not_supported
+    def _get_info_rom_image_version(gpu):
+        return {'info_rom_image_version':
+                pynvml.nvmlDeviceGetInforomImageVersion(gpu)}
+
+    @staticmethod
+    @handle_not_supported
+    def _get_device_power_state(gpu):
+        power_state = "P{}".format(pynvml.nvmlDeviceGetPowerState(gpu))
+        return {'power_state': power_state}
+
+    @staticmethod
+    @handle_not_supported
+    def _get_framebuffer_memory_stats(gpu):
+        mem_info = pynvml.nvmlDeviceGetMemoryInfo(gpu)
+        return {
+            'memory_fb_total_bytes': mem_info.total,
+            'memory_fb_used_bytes': mem_info.used,
+            'memory_fb_free_bytes': (mem_info.total - mem_info.used)
+        }
+
+    @staticmethod
+    @handle_not_supported
+    def _get_bar1_memory_stats(gpu):
+        mem_info = pynvml.nvmlDeviceGetBAR1MemoryInfo(gpu)
+        return {
+            'memory_bar1_total_bytes': mem_info.bar1Total,
+            'memory_bar1_used_bytes': mem_info.bar1Used,
+            'memory_bar1_free_bytes': (mem_info.bar1Total - mem_info.bar1Used)
+        }
+
+    @staticmethod
+    @handle_not_supported
+    def _get_utilisation_stats(gpu):
+        util = pynvml.nvmlDeviceGetUtilizationRates(gpu)
+        return {
+            'utilisation_gpu_percent': util.gpu,
+            'utilisation_memory_percent': util.memory
+        }
+
+    @staticmethod
+    @handle_not_supported
+    def _get_device_temperature(gpu):
+        return {'temperature_deg_c':
+                pynvml.nvmlDeviceGetTemperature(
+                    gpu, pynvml.NVML_TEMPERATURE_GPU)}
+
+    @staticmethod
+    @handle_not_supported
+    def _get_device_shutdown_temp(gpu):
+        return {'temperature_shutdown_deg_c':
+                pynvml.nvmlDeviceGetTemperatureThreshold(
+                    gpu, pynvml.NVML_TEMPERATURE_THRESHOLD_SHUTDOWN)}
+
+    @staticmethod
+    @handle_not_supported
+    def _get_device_slowdown_temp(gpu):
+        return {'temperature_slowdown_deg_c':
+                pynvml.nvmlDeviceGetTemperatureThreshold(
+                    gpu, pynvml.NVML_TEMPERATURE_THRESHOLD_SLOWDOWN)}
+
+    @staticmethod
+    @handle_not_supported
+    def _get_power_usage_watts(gpu):
+        return {'power_watts': (pynvml.nvmlDeviceGetPowerUsage(gpu) / 1000.0)}
+
+    @staticmethod
+    @handle_not_supported
+    def _get_power_limit_watts(gpu):
+        return {'power_limit_watts': (
+            pynvml.nvmlDeviceGetPowerManagementLimit(gpu) / 1000.0)}
+
+    @staticmethod
+    @handle_not_supported
+    def _get_clock_info(gpu):
+        return {
+            'clock_freq_gpu_mhz':
+                pynvml.nvmlDeviceGetClockInfo(gpu, pynvml.NVML_CLOCK_GRAPHICS),
+            'clock_freq_sm_mhz':
+                pynvml.nvmlDeviceGetClockInfo(gpu, pynvml.NVML_CLOCK_SM),
+            'clock_freq_memory_mhz':
+                pynvml.nvmlDeviceGetClockInfo(gpu, pynvml.NVML_CLOCK_MEM),
+            'clock_freq_video_mhz':
+                pynvml.nvmlDeviceGetClockInfo(gpu, pynvml.NVML_CLOCK_VIDEO)
+        }
+
+    @staticmethod
+    @handle_not_supported
+    def _get_clock_max_info(gpu):
+        return {
+            'clock_max_freq_gpu_mhz':
+                pynvml.nvmlDeviceGetMaxClockInfo(
+                    gpu, pynvml.NVML_CLOCK_GRAPHICS),
+            'clock_max_freq_sm_mhz':
+                pynvml.nvmlDeviceGetMaxClockInfo(gpu, pynvml.NVML_CLOCK_SM),
+            'clock_max_freq_memory_mhz':
+                pynvml.nvmlDeviceGetMaxClockInfo(gpu, pynvml.NVML_CLOCK_MEM),
+            'clock_max_freq_video_mhz':
+                pynvml.nvmlDeviceGetMaxClockInfo(gpu, pynvml.NVML_CLOCK_VIDEO)
+        }
+
+    @staticmethod
+    def _get_gpu_info():
+        pynvml.nvmlInit()
+        deviceCount = pynvml.nvmlDeviceGetCount()
+        all_info = []
+        for i in range(0, deviceCount):
+            gpu = pynvml.nvmlDeviceGetHandleByIndex(i)
+
+            dimensions = {}
+            dimensions.update(Nvidia._get_driver_version())
+            dimensions.update(Nvidia._get_device_uuid(gpu))
+            dimensions.update(Nvidia._get_info_rom_image_version(gpu))
+            dimensions.update(Nvidia._get_device_power_state(gpu))
+            dimensions.update(Nvidia._get_device_vbios_version(gpu))
+
+            measurements = {}
+            measurements.update(Nvidia._get_fan_speed_percent(gpu))
+            measurements.update(Nvidia._get_framebuffer_memory_stats(gpu))
+            measurements.update(Nvidia._get_bar1_memory_stats(gpu))
+            measurements.update(Nvidia._get_utilisation_stats(gpu))
+            measurements.update(Nvidia._get_device_temperature(gpu))
+            measurements.update(Nvidia._get_device_shutdown_temp(gpu))
+            measurements.update(Nvidia._get_device_slowdown_temp(gpu))
+            measurements.update(Nvidia._get_power_usage_watts(gpu))
+            measurements.update(Nvidia._get_power_limit_watts(gpu))
+            measurements.update(Nvidia._get_clock_info(gpu))
+            measurements.update(Nvidia._get_clock_max_info(gpu))
+
+            gpu_name = "{}_{}".format(
+                Nvidia._get_device_name(gpu).get('name'),
+                Nvidia._get_device_serial(gpu).get('serial'))
+            gpu_info = {
+                'name': gpu_name,
+                'dimensions': dimensions,
+                'measurements': measurements
+            }
+            all_info.append(gpu_info)
+        pynvml.nvmlShutdown()
+        return all_info
+
+    def check(self, instance):
+        for gpu_metrics in Nvidia._get_gpu_info():
+            for measurement, value in gpu_metrics['measurements'].items():
+                metric_name = '{0}.{1}'.format(
+                    _METRIC_NAME_PREFIX, measurement)
+                self.gauge(metric_name,
+                           value,
+                           device_name=gpu_metrics.get('name'),
+                           dimensions=gpu_metrics.get('dimensions'),
+                           value_meta=None)
+            log.debug('Collected info for GPU {}'.format(
+                gpu_metrics.get('name')))

--- a/stackhpc_monasca_agent_plugins/checks/nvidia.py
+++ b/stackhpc_monasca_agent_plugins/checks/nvidia.py
@@ -20,7 +20,6 @@ import pynvml
 log = logging.getLogger(__name__)
 
 _METRIC_NAME_PREFIX = "nvidia"
-_METRIC_NAME = "job_status"
 
 
 class Nvidia(checks.AgentCheck):

--- a/stackhpc_monasca_agent_plugins/checks/slurm.py
+++ b/stackhpc_monasca_agent_plugins/checks/slurm.py
@@ -28,11 +28,11 @@ _METRIC_NAME = "job_status"
 _SLURM_LIST_JOBS_CMD = ['/usr/bin/scontrol', '-o', 'show', 'job']
 _SLURM_LIST_NODES_CMD = ['/usr/bin/scontrol', '-o', 'show', 'node']
 
-_SLURM_JOB_FIELD_REGEX = ('^JobId=([\d]+)\sJobName=(.*?)\sUserI'
-                          'd=([\w-]+\([\w-]+\)) GroupId=([\w-]+\([\w-]+\))\s.*'
-                          'JobState=([\w]+)\s.*\sNodeList=(.*?)\s.*$')
-_SLURM_NODE_FIELD_REGEX = '^NodeName=(.*?)\s.*State=(.*?)\s.*$'
-_SLURM_NODE_SEQUENCE_REGEX = '^(.*)\[(.*)\]$'
+_SLURM_JOB_FIELD_REGEX = (r'^JobId=([\d]+)\sJobName=(.*?)\sUserI'
+                          r'd=([\w-]+\([\w-]+\)) GroupId=([\w-]+\([\w-]+\))\s.'
+                          r'*JobState=([\w]+)\s.*\sNodeList=(.*?)\s.*$')
+_SLURM_NODE_FIELD_REGEX = r'^NodeName=(.*?)\s.*State=(.*?)\s.*$'
+_SLURM_NODE_SEQUENCE_REGEX = r'^(.*)\[(.*)\]$'
 
 
 class Slurm(checks.AgentCheck):
@@ -91,7 +91,7 @@ class Slurm(checks.AgentCheck):
         :param field: Username or group and number
         :return: Username or group without number
         """
-        return re.sub('[(\d+)]', '', field)
+        return re.sub(r'[(\d+)]', '', field)
 
     def _get_jobs(self):
         raw_job_data = self._get_raw_job_data()

--- a/stackhpc_monasca_agent_plugins/detection/nvidia.py
+++ b/stackhpc_monasca_agent_plugins/detection/nvidia.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2018 StackHPC Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import logging
+import subprocess
+
+import monasca_setup.agent_config
+import monasca_setup.detection
+
+LOG = logging.getLogger(__name__)
+
+
+class NvidiaDetect(monasca_setup.detection.Plugin):
+    """Detects and configures nVidia plugin."""
+
+    def _detect(self):
+        self.available = False
+        if 'nvidia' not in subprocess.check_output(
+                ["lshw", "-C", "display"]).lower():
+            LOG.info('No nVidia hardware detected.')
+            return
+        self.available = True
+
+    def build_config(self):
+        config = monasca_setup.agent_config.Plugins()
+        config['nvidia'] = {
+            'init_config': None,
+            'instances': [{'name': 'nvidia_stats'}]}
+        return config

--- a/stackhpc_monasca_agent_plugins/tests/unit/checks/test_nvidia.py
+++ b/stackhpc_monasca_agent_plugins/tests/unit/checks/test_nvidia.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2018 StackHPC Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import mock
+import pynvml
+
+import stackhpc_monasca_agent_plugins.checks.nvidia as nvidia
+
+
+class MockNvidiaPlugin(nvidia.Nvidia):
+    def __init__(self):
+        # Don't call the base class constructor
+        pass
+
+    @staticmethod
+    def _set_dimensions(dimensions, instance=None):
+        return {'hostname': 'dummy_hostname'}
+
+
+class TestNvidiaNetwork(unittest.TestCase):
+    def setUp(self):
+        self.nvidia = MockNvidiaPlugin()
+
+    @mock.patch('pynvml.nvmlSystemGetDriverVersion',
+                autospec=True)
+    def test_dummy_property(self, mock_nvml_call):
+        mock_nvml_call.return_value = 'v1.2.3'
+        actual = MockNvidiaPlugin._get_driver_version()
+        expected = {'driver_version': 'v1.2.3'}
+        self.assertDictEqual(actual, expected)
+
+    @mock.patch('pynvml.nvmlSystemGetDriverVersion',
+                autospec=True)
+    def test_unsupported_property(self, mock_nvml_call):
+        excp = pynvml.NVMLError(pynvml.NVML_ERROR_NOT_SUPPORTED)
+        mock_nvml_call.side_effect = excp
+        actual = MockNvidiaPlugin._get_driver_version()
+        expected = {}
+        self.assertDictEqual(actual, expected)

--- a/stackhpc_monasca_agent_plugins/tests/unit/detection/test_nvidia.py
+++ b/stackhpc_monasca_agent_plugins/tests/unit/detection/test_nvidia.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2018 StackHPC Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import stackhpc_monasca_agent_plugins.detection.nvidia as nvidia
+
+
+class MockNvidiaDetectPlugin(nvidia.NvidiaDetect):
+    def __init__(self):
+        # Don't call the base class constructor
+        pass
+
+
+class TestNvidiaDetect(unittest.TestCase):
+    def setUp(self):
+        self.nvidia = MockNvidiaDetectPlugin()
+
+    def test_build_config(self):
+        config = self.nvidia.build_config()
+        self.assertIn('nvidia', config)


### PR DESCRIPTION
This is a plugin which uses nvidia-ml-py, a wrapper around the NVIDIA
Management Library to gather stats. It supports multiple GPUs per node.