### PR TITLE
remove version from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,6 @@ summary =
     by the Monasca Agent.
 home-page = https://github.com/stackhpc/stackhpc-monasca-agent-plugins
 license = Apache-2
-version = 0.0.1
 classifier =
     Development Status :: 4 - Beta
         Intended Audience :: Developers


### PR DESCRIPTION
After 1.0.0 has been release - hardcoded version value in setup.cfg created a problem:

```
INFO:kolla.common.utils.monasca-agent:    error in setup command: Error parsing /tmp/pip-req-build-t2tdtr2o/setup.cfg: ValueError: git history requires a target version of pbr.version.SemanticVersion(1.0.1), but target version is pbr.version.SemanticVersion(0.0.1)
```

This PR removes hardcoded value, after this change:
```
INFO:kolla.common.utils.monasca-agent:Successfully installed StackHPC-Monasca-Agent-plugins-1.0.1.dev4 nvidia-ml-py-375.53.1
```